### PR TITLE
CSS tweak to remove whitespace on New report tab

### DIFF
--- a/www/css/style.css
+++ b/www/css/style.css
@@ -45,6 +45,9 @@ map {
 #addReport {
     bottom: 1em;
 }
+#addForm {
+    margin-bottom: 0;
+}
 #addForm input {
     padding-left: 1em;
 }


### PR DESCRIPTION
Added margin-bottom property to eliminate whitespace at the end of the list.
